### PR TITLE
Get timezone from env variable

### DIFF
--- a/onadata/settings/common.py
+++ b/onadata/settings/common.py
@@ -49,7 +49,7 @@ DEFAULT_SESSION_EXPIRY_TIME = 21600  # 6 hours
 # timezone as the operating system.
 # If running in a Windows environment this must be set to the same as your
 # system time zone.
-TIME_ZONE = 'America/New_York'
+TIME_ZONE = os.environ.get('TIME_ZONE', 'America/New_York')
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html

--- a/onadata/settings/kc_environ.py
+++ b/onadata/settings/kc_environ.py
@@ -144,6 +144,15 @@ if EMAIL_BACKEND == 'django.core.mail.backends.filebased.EmailBackend':
     if not os.path.isdir(EMAIL_FILE_PATH):
         os.mkdir(EMAIL_FILE_PATH)
 
+# Local time zone for this installation. Choices can be found here:
+# http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
+# although not all choices may be available on all operating systems.
+# On Unix systems, a value of None will cause Django to use the same
+# timezone as the operating system.
+# If running in a Windows environment this must be set to the same as your
+# system time zone.
+TIME_ZONE = os.environ.get('TIME_ZONE', 'America/New_York')
+
 # Optional Sentry configuration: if desired, be sure to install Raven and set
 # RAVEN_DSN in the environment
 if 'RAVEN_DSN' in os.environ:

--- a/onadata/settings/production_example.py
+++ b/onadata/settings/production_example.py
@@ -48,7 +48,7 @@ DATABASES = {
 # timezone as the operating system.
 # If running in a Windows environment this must be set to the same as your
 # system time zone.
-TIME_ZONE = 'Africa/Lagos'
+TIME_ZONE = os.environ.get('TIME_ZONE', 'Africa/Lagos')
 
 TOUCHFORMS_URL = 'http://localhost:9000/'
 


### PR DESCRIPTION
Theoretically, it could be done only in `kc_environ.py` file, but using time zone from environmental variable with default value everywhere seems like sane solution