### PR TITLE
Change way of including admin routing

### DIFF
--- a/onadata/apps/main/urls.py
+++ b/onadata/apps/main/urls.py
@@ -26,7 +26,7 @@ urlpatterns = patterns(
 
     # django default stuff
     url(r'^accounts/', include('onadata.apps.main.registration_urls')),
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
 
     # oath2_provider


### PR DESCRIPTION
In Django 1.8, the admin routing was added by using `include()` function:
https://docs.djangoproject.com/en/1.8/ref/contrib/admin/#hooking-adminsite-instances-into-your-urlconf
whereas in Django 1.9, the method changed, and you just need to add pure
`admin.site.urls`, without wrapping them with `include()`:
https://docs.djangoproject.com/en/1.9/ref/contrib/admin/#hooking-adminsite-instances-into-your-urlconf

That said, at first sight the change seems to break things, because we are using
`Django>=1.8,<1.9`. However, with the previous conf, it was confirmed both
locally and on production that the admin routing is not working, and it was also
tested that the following change is making it work once again