### PR TITLE
Port kobocat base image to QED-based docker hub

### DIFF
--- a/Dockerfile.kobocat_base
+++ b/Dockerfile.kobocat_base
@@ -1,6 +1,7 @@
+# vim: syntax=dockerfile:
 # Base image to take care of installing `apt` and `pip` requirements. Also clones the `kobocat-template` repo.
 
-FROM kobotoolbox/base-kobos:latest
+FROM qeddockerhub/base-kobos:latest
 
 
 ENV KOBOCAT_TMP_DIR=/srv/kobocat_tmp \


### PR DESCRIPTION
Related: https://github.com/qedsoftware/kobo-docker/pull/7