### PR TITLE
Resolve missing data in exports issue using migrator 

### DIFF
--- a/onadata/apps/data_migration/factories.py
+++ b/onadata/apps/data_migration/factories.py
@@ -2,6 +2,7 @@ from .migrate_data import DataMigrator, SurveyFieldsHandler
 from .decisioner import MigrationDecisioner
 from .compare_xml import XFormsComparator
 from .backup_data import backup_xform
+from .xformtree import XFormTree
 
 
 def migration_decisioner_factory(old_xform, new_xform, **request_data):
@@ -28,7 +29,7 @@ def data_migrator_factory(old_xform, new_xform, backup_data=True,
         old_xform, new_xform, migration_decisioner.fields_changes, bind=True,
     ) if backup_data else None
 
-    fields_handler = SurveyFieldsHandler(migration_decisioner)
+    fields_handler = SurveyFieldsHandler(migration_decisioner, XFormTree(new_xform.xml))
     data_migrator = DataMigrator(new_xform, fields_handler,
                                  backup_data, xform_backup)
     return data_migrator

--- a/onadata/apps/data_migration/migrate_data.py
+++ b/onadata/apps/data_migration/migrate_data.py
@@ -67,6 +67,7 @@ class SurveyFieldsHandler(object):
         self.add_fields(survey_tree, self.decisioner.new_fields)
         self.modify_fields(survey_tree, self.decisioner.modifications)
         self.migrate_groups(survey_tree)
+        survey_tree.remove_duplicates()
 
     def add_fields(self, survey_tree, new_fields_tags):
         for field_to_add_tag in new_fields_tags:

--- a/onadata/apps/data_migration/migrate_data.py
+++ b/onadata/apps/data_migration/migrate_data.py
@@ -59,8 +59,9 @@ class DataMigrator(object):
 
 class SurveyFieldsHandler(object):
     """Handle fields operations."""
-    def __init__(self, migration_decisioner):
+    def __init__(self, migration_decisioner, xformtree):
         self.decisioner = migration_decisioner
+        self.xformtree = xformtree
 
     def alter_fields(self, survey_tree):
         self.add_fields(survey_tree, self.decisioner.new_fields)

--- a/onadata/apps/data_migration/migrate_data.py
+++ b/onadata/apps/data_migration/migrate_data.py
@@ -35,7 +35,7 @@ class DataMigrator(object):
     @staticmethod
     def set_proper_root_node(xform, survey_tree):
         new_root_id = xform.id_string
-        survey_tree.change_field_tag(survey_tree.root, new_root_id)
+        survey_tree.set_tag(survey_tree.root, new_root_id)
         survey_tree.set_field_attrib(survey_tree.root, attrib='id',
                                      new_value=new_root_id)
 
@@ -67,6 +67,7 @@ class SurveyFieldsHandler(object):
         self.add_fields(survey_tree, self.decisioner.new_fields)
         self.modify_fields(survey_tree, self.decisioner.modifications)
         self.migrate_groups(survey_tree)
+        survey_tree.sort(self.xformtree)
         survey_tree.remove_duplicates()
         survey_tree.remove_version()
 
@@ -84,7 +85,7 @@ class SurveyFieldsHandler(object):
         for prev_tag, new_tag in modifications.iteritems():
             groups = self.decisioner.fields_groups_new().get(prev_tag, [])
             field = survey_tree.get_or_create_field(prev_tag, groups=groups)
-            survey_tree.change_field_tag(field, new_tag)
+            survey_tree.set_tag(field, new_tag)
 
     def migrate_groups(self, survey_tree):
         changed_fields_groups = self.decisioner.changed_fields_groups()

--- a/onadata/apps/data_migration/migrate_data.py
+++ b/onadata/apps/data_migration/migrate_data.py
@@ -68,6 +68,7 @@ class SurveyFieldsHandler(object):
         self.modify_fields(survey_tree, self.decisioner.modifications)
         self.migrate_groups(survey_tree)
         survey_tree.remove_duplicates()
+        survey_tree.remove_version()
 
     def add_fields(self, survey_tree, new_fields_tags):
         for field_to_add_tag in new_fields_tags:

--- a/onadata/apps/data_migration/surveytree.py
+++ b/onadata/apps/data_migration/surveytree.py
@@ -109,3 +109,10 @@ class SurveyTree(XMLTree):
                 cls._remove_duplicates(prev_el)
             prev_el = next_el
         cls._remove_duplicates(next_el)
+
+    def remove_version(self):
+        try:
+            version_element = self.get_child_field(self.root, '__version__')
+            self.root.remove(version_element)
+        except MissingFieldException:
+            pass

--- a/onadata/apps/data_migration/surveytree.py
+++ b/onadata/apps/data_migration/surveytree.py
@@ -4,7 +4,7 @@ from lxml import etree
 
 from .xmltree import XMLTree, MissingFieldException
 from .xformtree import XFormTree
-from .common import compose as C, concat_map
+from .common import compose, concat_map
 
 
 class SurveyTree(XMLTree):
@@ -36,7 +36,7 @@ class SurveyTree(XMLTree):
 
     def find_group(self, name):
         """Find group named :group_name: or throw exception"""
-        return C(
+        return compose(
             self._get_first_element(name),
             partial(ifilter, lambda e: self.field_tag(e) == name),
         )(self.get_groups())
@@ -84,7 +84,7 @@ class SurveyTree(XMLTree):
         for el in ifilter(elem_in_order, tree):
             cls._sort(el, cls.get_child_field(pattern, cls.field_tag(el)))
 
-        for el in sorted(tree, key=C(order.index, cls.field_tag)):
+        for el in sorted(tree, key=compose(order.index, cls.field_tag)):
             tree.remove(el)
             tree.append(el)
 

--- a/onadata/apps/data_migration/surveytree.py
+++ b/onadata/apps/data_migration/surveytree.py
@@ -88,3 +88,24 @@ class SurveyTree(XMLTree):
         for el in sorted(tree, key=lambda e: order.index(e.tag)):
             tree.remove(el)
             tree.append(el)
+
+    def remove_duplicates(self):
+        """
+        Remove duplicated fields from the xml tree. It assumes that
+        fields in the tree are sorted
+        """
+        self._remove_duplicates(self.root)
+
+    @classmethod
+    def _remove_duplicates(cls, tree):
+        if cls.is_leaf(tree):
+            return
+        prev_el, next_el = tree[0], tree[0]
+        for next_el in tree[1:]:
+            are_leaves = cls.is_leaf(prev_el) and cls.is_leaf(next_el)
+            if are_leaves and cls.are_elements_equal(prev_el, next_el):
+                tree.remove(prev_el)
+            else:
+                cls._remove_duplicates(prev_el)
+            prev_el = next_el
+        cls._remove_duplicates(next_el)

--- a/onadata/apps/data_migration/tests/common.py
+++ b/onadata/apps/data_migration/tests/common.py
@@ -54,12 +54,13 @@ class CommonTestCase(TestCase):
                 e1=str(e1), e2=str(e2), attr=attr,
                 e1_attr=getattr(e1, attr), e2_attr=getattr(e2, attr)),
         )
-        cmp_tails = lambda e1, e2: (
-            remove_whitespaces(e1.tail or '') != remove_whitespaces(e2.tail or '')
+        cmp_vals = lambda e1, e2, attr: (
+            remove_whitespaces(getattr(e1, attr) or '') != \
+            remove_whitespaces(getattr(e2, attr) or '')
         )
         if e1.tag != e2.tag: return False, get_msg(e1, e2, 'tag')
-        if e1.text != e2.text: return False, get_msg(e1, e2, 'text')
-        if cmp_tails(e1, e2): return False, get_msg(e1, e2, 'tail')
+        if cmp_vals(e1, e2, 'text'): return False, get_msg(e1, e2, 'text')
+        if cmp_vals(e1, e2, 'tail'): return False, get_msg(e1, e2, 'tail')
         if e1.attrib != e2.attrib: return False, get_msg(e1, e2, 'attrib')
         if len(e1) != len(e2): return False, "len({}) != len({})".format(str(e1), str(e2))
 

--- a/onadata/apps/data_migration/tests/fixtures/case1.py
+++ b/onadata/apps/data_migration/tests/fixtures/case1.py
@@ -145,60 +145,68 @@ form_xml_case_1_after = '''<?xml version="1.0" encoding="utf-8"?>
 
 survey_template = '''<Survey xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms/" id="Survey">
   <formhub>
-    <uuid>{}</uuid>
+    <uuid>{uuid}</uuid>
   </formhub>
-  <name>{}</name>
+  <name>{name}</name>
   <gender>male</gender>
   <photo/>
-  <date>{}</date>
+  <date>{date}</date>
   <location>-1 1.1 1 2</location>
-  <age>{}</age>
+  <age>{age}</age>
   <thanks/>
   <start_time>2016-01-01T18:32:20.000+03:00</start_time>
   <end_time>2016-01-01T18:33:03.000+03:00</end_time>
   <today>2016-01-01</today>
   <imei>example.com:d123das</imei>
   <meta>
-    <instanceID>uuid:{}</instanceID>
+    <instanceID>uuid:{instance_uuid}</instanceID>
   </meta>
 </Survey>
 '''
 
 survey_after_migration_template = '''<Survey2 xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms/" id="Survey2">
   <formhub>
-    <uuid>{}</uuid>
+    <uuid>{uuid}</uuid>
   </formhub>
-  <first_name>{}</first_name>
+  <first_name>{name}</first_name>
+  <last_name>Fowler</last_name>
+  <birthday/>
   <gender>male</gender>
   <photo/>
-  <date>{}</date>
+  <age>{age}</age>
   <location>-1 1.1 1 2</location>
-  <age>{}</age>
+  <date>{date}</date>
   <thanks/>
   <start_time>2016-01-01T18:32:20.000+03:00</start_time>
   <end_time>2016-01-01T18:33:03.000+03:00</end_time>
   <today>2016-01-01</today>
   <imei>example.com:d123das</imei>
   <meta>
-    <instanceID>uuid:{}</instanceID>
+    <instanceID>uuid:{instance_uuid}</instanceID>
   </meta>
-  <last_name>Fowler</last_name>
-  <birthday/>
 </Survey2>
 '''
 
 
-_first_survey_data = (
-    '123abc', 'Alonzo Church', '2000-01-01', '50', 'das-d123-dsa-dsa-dsa'
-)
-_second_survey_data = (
-    '456asd', 'Richard Feynman', '1988-02-15', '70', 'qwe-ert-yui-opa-sdf'
-)
+_first_survey_data = {
+    'uuid': '123abc',
+    'name': 'Alonzo Church',
+    'date': '2000-01-01',
+    'age': '50',
+    'instance_uuid': 'das-d123-dsa-dsa-dsa',
+}
+_second_survey_data = {
+    'uuid': '456asd',
+    'name': 'Richard Feynman',
+    'date': '1988-02-15',
+    'age': '70',
+    'instance_uuid':'qwe-ert-yui-opa-sdf',
+}
 
-survey_xml = survey_template.format(*_first_survey_data)
-survey_xml_second = survey_template.format(*_second_survey_data)
+survey_xml = survey_template.format(**_first_survey_data)
+survey_xml_second = survey_template.format(**_second_survey_data)
 
-survey_after_migration = survey_after_migration_template.format(*_first_survey_data)
-survey_after_migration_second = survey_after_migration_template.format(*_second_survey_data)
+survey_after_migration = survey_after_migration_template.format(**_first_survey_data)
+survey_after_migration_second = survey_after_migration_template.format(**_second_survey_data)
 
 append_extra_data = lambda survey, data: survey.replace('</Survey>', data + '</Survey>')

--- a/onadata/apps/data_migration/tests/fixtures/case2.py
+++ b/onadata/apps/data_migration/tests/fixtures/case2.py
@@ -203,10 +203,10 @@ survey_2_after_migration = '''<tutorial2 xmlns:jr="http://openrosa.org/javarosa"
   <has_children>0</has_children>
   <gps>0.000001 0.000001 0 0</gps>
   <web_browsers>chrome</web_browsers>
+  <mood>good</mood>
   <meta>
     <instanceID>uuid:fc9eebf7-49f2-4857-b51f-bf0e385a53f5</instanceID>
   </meta>
-  <mood>good</mood>
 </tutorial2>
 '''
 

--- a/onadata/apps/data_migration/tests/fixtures/case3.py
+++ b/onadata/apps/data_migration/tests/fixtures/case3.py
@@ -175,42 +175,6 @@ survey_after_migration_template_3 = '''<SurveyGroups2 xmlns:jr="http://openrosa.
   <formhub>
     <uuid>{formhub_uuid}</uuid>
   </formhub>
-  <gender>male</gender>
-  <new_record_already_in_template__wrong_group>
-  </new_record_already_in_template__wrong_group>
-  <photo/>
-  <location>-1 1.1 1 2</location>
-  <redundant_group>
-  </redundant_group>
-  <thanks/>
-  <start_time>2016-01-01T18:32:20.000+03:00</start_time>
-  <end_time>2016-01-01T18:33:03.000+03:00</end_time>
-  <today>2016-01-01</today>
-  <imei>example.com:d123das</imei>
-  <meta>
-    <instanceID>uuid:{instance_uuid}</instanceID>
-  </meta>
-  <private>
-    <first_name>{name}</first_name>
-    <last_name/>
-  </private>
-  <group_1>
-    <group_2>
-      <group_3>
-        <date/>
-      </group_3>
-    </group_2>
-  </group_1>
-  <group_age>
-    <age>{age}</age>
-  </group_age>
-</SurveyGroups2>
-'''
-
-survey_after_migration_template_3_sorted = '''<SurveyGroups2 xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms/" id="SurveyGroups2">
-  <formhub>
-    <uuid>{formhub_uuid}</uuid>
-  </formhub>
   <private>
     <first_name>{name}</first_name>
     <last_name/>
@@ -253,6 +217,5 @@ _survey_data_3 = {
 
 survey_xml_3 = survey_template_3.format(**_survey_data_3)
 survey_3_after_migration = survey_after_migration_template_3.format(**_survey_data_3)
-survey_3_after_migration_sorted = survey_after_migration_template_3_sorted.format(**_survey_data_3)
 
 append_extra_data_3 = lambda survey, data: survey.replace('</SurveyGroups>', data + '</SurveyGroups>')

--- a/onadata/apps/data_migration/tests/fixtures/case3.py
+++ b/onadata/apps/data_migration/tests/fixtures/case3.py
@@ -164,6 +164,7 @@ survey_template_3 = '''<SurveyGroups xmlns:jr="http://openrosa.org/javarosa" xml
   <end_time>2016-01-01T18:33:03.000+03:00</end_time>
   <today>2016-01-01</today>
   <imei>example.com:d123das</imei>
+  <__version__>xyz</__version__>
   <meta>
     <instanceID>uuid:{instance_uuid}</instanceID>
   </meta>

--- a/onadata/apps/data_migration/tests/fixtures/case3.py
+++ b/onadata/apps/data_migration/tests/fixtures/case3.py
@@ -147,9 +147,9 @@ form_xml_case_3_after = '''<?xml version="1.0" encoding="utf-8"?>
 
 survey_template_3 = '''<SurveyGroups xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms/" id="SurveyGroups">
   <formhub>
-    <uuid>{}</uuid>
+    <uuid>{formhub_uuid}</uuid>
   </formhub>
-  <name>{}</name>
+  <name>{name}</name>
   <gender>male</gender>
   <new_record_already_in_template__wrong_group>
     <date/>
@@ -157,7 +157,7 @@ survey_template_3 = '''<SurveyGroups xmlns:jr="http://openrosa.org/javarosa" xml
   <photo/>
   <location>-1 1.1 1 2</location>
   <redundant_group>
-    <age>{}</age>
+    <age>{age}</age>
   </redundant_group>
   <thanks/>
   <start_time>2016-01-01T18:32:20.000+03:00</start_time>
@@ -165,14 +165,14 @@ survey_template_3 = '''<SurveyGroups xmlns:jr="http://openrosa.org/javarosa" xml
   <today>2016-01-01</today>
   <imei>example.com:d123das</imei>
   <meta>
-    <instanceID>uuid:{}</instanceID>
+    <instanceID>uuid:{instance_uuid}</instanceID>
   </meta>
 </SurveyGroups>
 '''
 
 survey_after_migration_template_3 = '''<SurveyGroups2 xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms/" id="SurveyGroups2">
   <formhub>
-    <uuid>{}</uuid>
+    <uuid>{formhub_uuid}</uuid>
   </formhub>
   <gender>male</gender>
   <new_record_already_in_template__wrong_group>
@@ -187,10 +187,10 @@ survey_after_migration_template_3 = '''<SurveyGroups2 xmlns:jr="http://openrosa.
   <today>2016-01-01</today>
   <imei>example.com:d123das</imei>
   <meta>
-    <instanceID>uuid:{}</instanceID>
+    <instanceID>uuid:{instance_uuid}</instanceID>
   </meta>
   <private>
-    <first_name>{}</first_name>
+    <first_name>{name}</first_name>
     <last_name/>
   </private>
   <group_1>
@@ -201,16 +201,57 @@ survey_after_migration_template_3 = '''<SurveyGroups2 xmlns:jr="http://openrosa.
     </group_2>
   </group_1>
   <group_age>
-    <age>{}</age>
+    <age>{age}</age>
   </group_age>
 </SurveyGroups2>
 '''
 
+survey_after_migration_template_3_sorted = '''<SurveyGroups2 xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms/" id="SurveyGroups2">
+  <formhub>
+    <uuid>{formhub_uuid}</uuid>
+  </formhub>
+  <private>
+    <first_name>{name}</first_name>
+    <last_name/>
+  </private>
+  <gender>male</gender>
+  <photo/>
+  <group_age>
+    <age>{age}</age>
+  </group_age>
+  <group_1>
+    <group_2>
+      <group_3>
+        <date/>
+      </group_3>
+    </group_2>
+  </group_1>
+  <location>-1 1.1 1 2</location>
+  <new_record_already_in_template__wrong_group>
+  </new_record_already_in_template__wrong_group>
+  <redundant_group>
+  </redundant_group>
+  <thanks/>
+  <start_time>2016-01-01T18:32:20.000+03:00</start_time>
+  <end_time>2016-01-01T18:33:03.000+03:00</end_time>
+  <today>2016-01-01</today>
+  <imei>example.com:d123das</imei>
+  <meta>
+    <instanceID>uuid:{instance_uuid}</instanceID>
+  </meta>
+</SurveyGroups2>
+'''
 
-_survey_data_3 = ('123abc', 'Kurt Godel', '50', 'das-d123-dsa-dsa-dsa')
-_survey_after_migration_data_3 = ('123abc', 'das-d123-dsa-dsa-dsa', 'Kurt Godel', '50')
 
-survey_xml_3 = survey_template_3.format(*_survey_data_3)
-survey_3_after_migration = survey_after_migration_template_3.format(*_survey_after_migration_data_3)
+_survey_data_3 = {
+    'formhub_uuid': '123abc',
+    'name': 'Kurt Godel',
+    'age': '50',
+    'instance_uuid': 'das-d123-dsa-dsa-dsa',
+}
+
+survey_xml_3 = survey_template_3.format(**_survey_data_3)
+survey_3_after_migration = survey_after_migration_template_3.format(**_survey_data_3)
+survey_3_after_migration_sorted = survey_after_migration_template_3_sorted.format(**_survey_data_3)
 
 append_extra_data_3 = lambda survey, data: survey.replace('</SurveyGroups>', data + '</SurveyGroups>')

--- a/onadata/apps/data_migration/tests/fixtures/groups.py
+++ b/onadata/apps/data_migration/tests/fixtures/groups.py
@@ -96,7 +96,6 @@ survey_xml_groups_after = """
   <start>2017-11-10T17:57:48.000+01:00</start>
   <end>2017-11-10T18:00:02.000+01:00</end>
   
-  <__version__>vaEytJG3RWgRJMAuCnKWtC</__version__>
   <meta>
     <instanceID>uuid:ec5f2a1c-1cbd-49ac-8ab7-8be1ba33c14f</instanceID>
   </meta>
@@ -241,7 +240,6 @@ survey_xml_groups_after__second = """
   <math_degree>Ph.D</math_degree>
   <current_date>3.11.1971</current_date>
 
-  <__version__>vaEytJG3RWgRJMAuCnKWtC</__version__>
   <meta>
     <instanceID>uuid:ec5f2a1c-1cbd-49ac-8ab7-8be1ba33c14f</instanceID>
   </meta>

--- a/onadata/apps/data_migration/tests/fixtures/groups.py
+++ b/onadata/apps/data_migration/tests/fixtures/groups.py
@@ -89,22 +89,21 @@ survey_xml_groups_before = """
 
 survey_xml_groups_after = """
 <groups2 xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" id="groups2" version="vaEytJG3RWgRJMAuCnKWtC">
-  <formhub>
-    <uuid>30760c2faa6c498a83f0c6a7ff761f83</uuid>
-  </formhub>
-  
   <start>2017-11-10T17:57:48.000+01:00</start>
   <end>2017-11-10T18:00:02.000+01:00</end>
-  
-  <meta>
-    <instanceID>uuid:ec5f2a1c-1cbd-49ac-8ab7-8be1ba33c14f</instanceID>
-  </meta>
 
   <group_transformations>
     <isomorphism/>
     <homomorphism>identity</homomorphism>
   </group_transformations>
-  
+
+  <formhub>
+    <uuid>30760c2faa6c498a83f0c6a7ff761f83</uuid>
+  </formhub>
+
+  <meta>
+    <instanceID>uuid:ec5f2a1c-1cbd-49ac-8ab7-8be1ba33c14f</instanceID>
+  </meta>
 </groups2>
 """
 
@@ -231,18 +230,8 @@ survey_xml_groups_before__second = """
 
 survey_xml_groups_after__second = """
 <AlgebraicTypes2 xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" id="AlgebraicTypes2" version="vkvxz56QzsTUnnJvSQDj4R">
-  <formhub>
-    <uuid>30760c2faa6c498a83f0c6a7ff761f83</uuid>
-  </formhub>
   <start>2017-11-10T17:57:48.000+01:00</start>
   <end>2017-11-10T18:00:02.000+01:00</end>
-  
-  <math_degree>Ph.D</math_degree>
-  <current_date>3.11.1971</current_date>
-
-  <meta>
-    <instanceID>uuid:ec5f2a1c-1cbd-49ac-8ab7-8be1ba33c14f</instanceID>
-  </meta>
 
   <group_transformations>
     <bijective>
@@ -254,6 +243,16 @@ survey_xml_groups_after__second = """
     </bijective>
     <endomorphism>f: G -&gt; G</endomorphism>
   </group_transformations>
- 
+
+  <math_degree>Ph.D</math_degree>
+  <current_date>3.11.1971</current_date>
+  <formhub>
+    <uuid>30760c2faa6c498a83f0c6a7ff761f83</uuid>
+  </formhub>
+
+  <meta>
+    <instanceID>uuid:ec5f2a1c-1cbd-49ac-8ab7-8be1ba33c14f</instanceID>
+  </meta>
+
 </AlgebraicTypes2>
 """

--- a/onadata/apps/data_migration/tests/test_restore_backup.py
+++ b/onadata/apps/data_migration/tests/test_restore_backup.py
@@ -216,7 +216,7 @@ class BackupRestoreSecondTestCase(CommonBackupRestoreTestCase,
             self.xform_new.xml,
             fixtures.form_xml_case_2.replace('tutorial', 'tutorial2'),
         )
-        self.assertEqualIgnoringWhitespaces(
+        self.assertXMLsIsomorphic(
             self.xform_new.instances.first().xml,
             self._append_survey_data(fixtures.survey_xml_2),
         )

--- a/onadata/apps/data_migration/tests/test_survey_tree.py
+++ b/onadata/apps/data_migration/tests/test_survey_tree.py
@@ -1,3 +1,4 @@
+import re
 from lxml import etree
 
 from onadata.apps.data_migration.xformtree import XFormTree
@@ -289,6 +290,7 @@ class SurveyTreeWithGroupsOperationsTest(CommonTestCase):
         for field, groups in zip(fields, fields_groups):
             self.survey_prev.insert_field_into_group_chain(field, groups)
 
-        expected_xml = self.survey_prev.to_string()\
+        actual_xml = self.survey_prev.to_string()\
             .replace('TestGroup', 'AlgebraicTypes2')
-        self.assertXMLsEqual(expected_xml, fixtures.survey_xml_groups_after__second)
+        actual_xml = re.sub(r"<__version__>.*</__version__>", "", actual_xml)
+        self.assertXMLsEqual(fixtures.survey_xml_groups_after__second, actual_xml)

--- a/onadata/apps/data_migration/tests/test_survey_tree.py
+++ b/onadata/apps/data_migration/tests/test_survey_tree.py
@@ -157,6 +157,41 @@ class SurveyTreeOperationsTest(CommonTestCase):
                              fixtures.survey_3_after_migration_sorted)
 
 
+    def test_remove_duplicates(self):
+        survey_tree = SurveyTree("""
+            <Survey>
+                <element>value</element>
+                <element>value</element>
+                <nested>
+                    <happy_little_tag>content</happy_little_tag>
+                    <should_be_removed id="a">content</should_be_removed>
+                    <should_be_removed id="a">content</should_be_removed>
+                    <should_be_removed id="a">content</should_be_removed>
+                    <should_be_removed id="a">content</should_be_removed>
+                </nested>
+                <leave_intact/>
+                <meta>value1</meta>
+                <meta>value2</meta>
+                <meta>value2</meta>
+                <meta id="x">value2</meta>
+            </Survey>
+        """)
+        survey_tree.remove_duplicates()
+        self.assertXMLsEqual(survey_tree.to_string(), '''
+            <Survey>
+                <element>value</element>
+                <nested>
+                    <happy_little_tag>content</happy_little_tag>
+                    <should_be_removed id="a">content</should_be_removed>
+                </nested>
+                <leave_intact/>
+                <meta>value1</meta>
+                <meta>value2</meta>
+                <meta id="x">value2</meta>
+            </Survey>
+        ''')
+
+
 class SurveyTreeWithGroupsOperationsTest(CommonTestCase):
     def setUp(self):
         super(SurveyTreeWithGroupsOperationsTest, self).setUp()

--- a/onadata/apps/data_migration/tests/test_survey_tree.py
+++ b/onadata/apps/data_migration/tests/test_survey_tree.py
@@ -41,12 +41,12 @@ class SurveyTreeOperationsTest(CommonTestCase):
         self.survey.permanently_remove_field(field)
         self.assertEqual(self.survey.get_fields_names(), expected)
 
-    def test_change_field_tag(self):
+    def test_set_tag(self):
         expected = fixtures.FIELDS[:]
         pos = expected.index('name')
         expected[pos] = 'first_name'
         field = self.survey.get_field('name')
-        self.survey.change_field_tag(field, 'first_name')
+        self.survey.set_tag(field, 'first_name')
         self.assertEqual(self.survey.get_fields_names(), expected)
 
     def test_get_or_create_field(self):
@@ -155,7 +155,7 @@ class SurveyTreeOperationsTest(CommonTestCase):
     def test_sort(self):
         self.survey_3.sort(self.xformtree_3)
         self.assertXMLsEqual(self.survey_3.to_string(),
-                             fixtures.survey_3_after_migration_sorted)
+                             fixtures.survey_3_after_migration)
 
 
     def test_remove_duplicates(self):
@@ -293,4 +293,4 @@ class SurveyTreeWithGroupsOperationsTest(CommonTestCase):
         actual_xml = self.survey_prev.to_string()\
             .replace('TestGroup', 'AlgebraicTypes2')
         actual_xml = re.sub(r"<__version__>.*</__version__>", "", actual_xml)
-        self.assertXMLsEqual(fixtures.survey_xml_groups_after__second, actual_xml)
+        self.assertXMLsIsomorphic(fixtures.survey_xml_groups_after__second, actual_xml)

--- a/onadata/apps/data_migration/tests/test_xformtree.py
+++ b/onadata/apps/data_migration/tests/test_xformtree.py
@@ -83,9 +83,9 @@ class XFormTreeOperationsTestCase(TestCase):
         self.assertTrue(self.prev_tree.to_string())
 
     def test_set_tag(self):
-        tag_name = self.prev_tree.get_head_instance().tag
+        field = self.prev_tree.get_head_instance()
         new_tag_name = 'Survey2'
-        self.prev_tree.set_tag(tag_name, new_tag_name)
+        self.prev_tree.set_tag(field, new_tag_name)
         self.assertEqual(
             self.prev_tree.clean_tag(self.prev_tree.get_head_instance().tag),
             new_tag_name

--- a/onadata/apps/data_migration/tree.py
+++ b/onadata/apps/data_migration/tree.py
@@ -1,3 +1,6 @@
+from collections import defaultdict
+from itertools import chain
+
 
 class Tree(object):
     def __init__(self, label='root', parent=None, children=None):

--- a/onadata/apps/data_migration/xformtree.py
+++ b/onadata/apps/data_migration/xformtree.py
@@ -20,12 +20,6 @@ class XFormTree(XMLTree):
         except IndexError:
             return None
 
-    def set_tag(self, tag_name, value):
-        el = self.find_element_in_tree(tag_name)
-        cleaned_tag = self.field_tag(el)
-        el.tag = el.tag.replace(cleaned_tag, value)
-        return el
-
     def get_head_content(self):
         """XML Heads content."""
         return self.root[0][1]
@@ -151,7 +145,7 @@ class XFormTree(XMLTree):
     def rename_head_tag(self, name):
         instance = self.get_head_instance()
         instance.attrib['id'] = name
-        self.set_tag(instance.tag, name)
+        self.set_tag(instance, name)
 
     def _replace_in_nodeset_paths(self, old_val, new_val):
         bind_nodesets = self.get_head_binds()

--- a/onadata/apps/data_migration/xformtree.py
+++ b/onadata/apps/data_migration/xformtree.py
@@ -11,6 +11,8 @@ class XFormTree(XMLTree):
     xls forms: http://xlsform.org/
     w3c xforms: https://www.w3.org/MarkUp/Forms/#waXForms
     """
+    DATA_STRUCT_PATH = ["head", "model", "instance"]
+
     def find_element_in_tree(self, searched_tag):
         query = "//*[local-name()='%s']" % self.clean_tag(searched_tag)
         try:

--- a/onadata/apps/data_migration/xmltree.py
+++ b/onadata/apps/data_migration/xmltree.py
@@ -32,6 +32,10 @@ class XMLTree(object):
         return etree.tostring(self.root, pretty_print=pretty,
                               xml_declaration=True, encoding='utf-8')
 
+    def set_tag(self, field, value):
+        cleaned_tag = self.field_tag(field)
+        field.tag = field.tag.replace(cleaned_tag, value)
+
     def get_fields(self):
         """Parse and return list of all fields in form."""
         return self.retrieve_leaf_elems(self.root)

--- a/onadata/apps/data_migration/xmltree.py
+++ b/onadata/apps/data_migration/xmltree.py
@@ -1,3 +1,4 @@
+import re
 from functools import partial
 from itertools import ifilter
 from lxml import etree
@@ -53,6 +54,10 @@ class XMLTree(object):
     def _get_matching_elems(self, condition_func):
         """Return elems that match condition"""
         return ifilter(condition_func, self.get_all_elems())
+
+    @staticmethod
+    def is_leaf(element):
+        return len(element.getchildren()) == 0
 
     @classmethod
     def retrieve_leaf_elems(cls, element):
@@ -134,3 +139,8 @@ class XMLTree(object):
     @classmethod
     def field_tag(cls, field):
         return cls.clean_tag(field.tag)
+
+    @classmethod
+    def are_elements_equal(cls, e1, e2):
+        to_str = lambda el: re.sub(r"\s+", "", etree.tostring(el))
+        return to_str(e1) == to_str(e2)


### PR DESCRIPTION
- Sort submission trees after data migration according to xform structure
- Remove duplicated fields
- Remove submission version after data migration
- Ensure that clean tags are used in `surveytree` module